### PR TITLE
Persist proposed blocks to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 
 .vscode/**
 block-scorer
+
+*data/

--- a/pkg/analysis/persist.go
+++ b/pkg/analysis/persist.go
@@ -1,0 +1,57 @@
+package analysis
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/attestantio/go-eth2-client/api"
+)
+
+func (b *ClientLiveData) PersistBlock(block api.VersionedProposal) error {
+	if block.IsEmpty() {
+		log.Errorf("attempt to persist empty block")
+		return fmt.Errorf("empty block persist")
+	}
+
+	folder := fmt.Sprintf("%s/%s/%s/", b.blocksDir, b.Eth2Provider.Label, b.client)
+
+	// check if foder exists
+
+	if _, err := os.Stat(folder); errors.Is(err, os.ErrNotExist) {
+		err := os.MkdirAll(folder, os.ModePerm)
+		if err != nil {
+			log.Errorf("could not create blocks dir: %s", err)
+		}
+	}
+
+	slot, err := block.Slot()
+	if err != nil {
+		log.Errorf("could not persist block, slot not identified: %s", err)
+		return err
+	}
+
+	// files are always new, block proposals are always in a new slot
+	fileName := fmt.Sprintf("slot_%d.json", slot)
+	fullPath := fmt.Sprintf("%s%s", folder, fileName)
+
+	// create file
+	f, err := os.Create(fullPath)
+	if err != nil {
+		log.Errorf("could not create file to persist block (%s): %s", fullPath, err)
+	}
+
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	written, err := w.WriteString(block.String())
+	if err != nil {
+		log.Errorf("error writing block to %s: %s", fullPath, err)
+		return err
+	}
+	log.Debugf("wrote %d bytes to %s", written, fullPath)
+
+	w.Flush()
+	return nil
+}

--- a/pkg/analysis/persist.go
+++ b/pkg/analysis/persist.go
@@ -9,21 +9,25 @@ import (
 	"github.com/attestantio/go-eth2-client/api"
 )
 
+func (b *ClientLiveData) CheckBlocksFolder() error {
+
+	// check if foder exists
+	log.Debugf("checking folder %s exists...", b.blocksDir)
+	if _, err := os.Stat(b.blocksDir); errors.Is(err, os.ErrNotExist) {
+		log.Debugf("creating folder %s", b.blocksDir)
+		err := os.MkdirAll(b.blocksDir, os.ModePerm)
+		if err != nil {
+			log.Errorf("could not create blocks dir: %s", err)
+			return fmt.Errorf("could not create blocks dir: %s", err)
+		}
+	}
+	return nil
+}
+
 func (b *ClientLiveData) PersistBlock(block api.VersionedProposal) error {
 	if block.IsEmpty() {
 		log.Errorf("attempt to persist empty block")
 		return fmt.Errorf("empty block persist")
-	}
-
-	folder := fmt.Sprintf("%s/%s/%s/", b.blocksDir, b.Eth2Provider.Label, b.client)
-
-	// check if foder exists
-
-	if _, err := os.Stat(folder); errors.Is(err, os.ErrNotExist) {
-		err := os.MkdirAll(folder, os.ModePerm)
-		if err != nil {
-			log.Errorf("could not create blocks dir: %s", err)
-		}
 	}
 
 	slot, err := block.Slot()
@@ -34,7 +38,7 @@ func (b *ClientLiveData) PersistBlock(block api.VersionedProposal) error {
 
 	// files are always new, block proposals are always in a new slot
 	fileName := fmt.Sprintf("slot_%d.json", slot)
-	fullPath := fmt.Sprintf("%s%s", folder, fileName)
+	fullPath := fmt.Sprintf("%s%s", b.blocksDir, fileName)
 
 	// create file
 	f, err := os.Create(fullPath)

--- a/pkg/app/service.go
+++ b/pkg/app/service.go
@@ -45,7 +45,8 @@ func NewAppService(pCtx context.Context,
 	dbEndpooint string,
 	dbWorkers int,
 	metrics []string,
-	exporterService *exporter.ExporterService) (*AppService, error) {
+	exporterService *exporter.ExporterService,
+	blocksDir string) (*AppService, error) {
 
 	ctx, cancel := context.WithCancel(pCtx)
 	batchLen := len(bnEndpoints)
@@ -72,7 +73,7 @@ func NewAppService(pCtx context.Context,
 		label := strings.Split(bnEndpoints[i], "/")[1]
 		endpoint := strings.Split(bnEndpoints[i], "/")[2]
 		// newAnalyzer, err := analysis.NewBlockAnalyzer(ctx, label, endpoint, time.Second*5)
-		newAnalyzer, err := analysis.NewBlockAnalyzer(ctx, client, label, endpoint, time.Second*5, dbClient)
+		newAnalyzer, err := analysis.NewBlockAnalyzer(ctx, client, label, endpoint, time.Second*5, dbClient, blocksDir)
 
 		if err != nil {
 			log.Errorf("could not create client for endpoint: %s ", endpoint, err)

--- a/pkg/utils/client.go
+++ b/pkg/utils/client.go
@@ -6,6 +6,7 @@ const (
 	TekuClient       = "Teku"
 	NimbusClient     = "Nimbus"
 	LodestarClient   = "Lodestar"
+	GrandineClient   = "Grandine"
 )
 
 func CheckValidClientName(name string) bool {


### PR DESCRIPTION
# Motivation
As we are proposing blocks it could be interesting to store those blocks in disk for a post analysis offline.
This PR addresses this single problem, of storing blocks in an organised way to disk.

# Description
A folder will be created if it does not exist and blocks will be stored if they are proposed.
Blocks will be stored according to the given labels for each client:
for a configuration like: `Lighthouse/hw-analysis-v3/localhost:5052, Nimbus/hw-analysis-v3/localhost:5053

![image](https://github.com/migalabs/streameth/assets/18716811/29841e4f-0bdb-4fd1-a542-f53de172da89)

# TODOs
- [x] Receive folder parameter by command line
- [x] Create folder if it does not exist
- [x] Add blocks in json format to the given folder
- [x] Only check folder creation once   