### PR TITLE
Persist client name in database

### DIFF
--- a/pkg/analysis/analyzer.go
+++ b/pkg/analysis/analyzer.go
@@ -151,6 +151,7 @@ func (b *ClientLiveData) ProposeNewBlock(slot phase0.Slot) {
 	// Store in DB
 	params := make([]interface{}, 0)
 	params = append(params, metrics.Slot)
+	params = append(params, metrics.ClientName)
 	params = append(params, metrics.Label)
 	params = append(params, metrics.Score)
 	params = append(params, metrics.Duration)
@@ -182,7 +183,7 @@ func (b *ClientLiveData) ProposeNewBlock(slot phase0.Slot) {
 	// b.ProcessNewHead <- struct{}{} // Allow the new head to update attestations
 }
 
-func (b ClientLiveData) GetLabel() string {
+func (b *ClientLiveData) GetLabel() string {
 	return b.label
 }
 

--- a/pkg/analysis/events.go
+++ b/pkg/analysis/events.go
@@ -44,7 +44,7 @@ func (b *ClientLiveData) HandleHeadEvent(event *api_v1.Event) {
 		for i := b.CurrentHeadSlot + 1; i < uint64(data.Slot); i++ {
 			params := make([]interface{}, 0)
 			params = append(params, i)
-			params = append(params, b.Eth2Provider.Label)
+			params = append(params, b.label)
 			writeTask := postgresql.WriteTask{
 				QueryString: postgresql.InsertNewMissedBlock,
 				Params:      params,
@@ -55,7 +55,7 @@ func (b *ClientLiveData) HandleHeadEvent(event *api_v1.Event) {
 	b.CurrentHeadSlot = uint64(data.Slot)
 	params := make([]interface{}, 0)
 	params = append(params, int(data.Slot))
-	params = append(params, b.Eth2Provider.Label)
+	params = append(params, b.label)
 	params = append(params, timestamp)
 	writeTask := postgresql.WriteTask{
 		QueryString: postgresql.InsertNewBlock,
@@ -96,7 +96,7 @@ func (b *ClientLiveData) HandleAttestationEvent(event *api_v1.Event) {
 
 	// create params to be written, same for all validators (same attestation)
 	baseParams := make([]interface{}, 0)
-	baseParams = append(baseParams, b.Eth2Provider.Label)
+	baseParams = append(baseParams, b.label)
 	baseParams = append(baseParams, uint64(data.Data.Slot))
 	baseParams = append(baseParams, uint64(data.Data.Index))
 	baseParams = append(baseParams, timestamp)
@@ -138,7 +138,7 @@ func (b *ClientLiveData) HandleReOrgEvent(event *api_v1.Event) {
 	log.Debugf("New Reorg Evenet")
 
 	baseParams := make([]interface{}, 0)
-	baseParams = append(baseParams, b.Eth2Provider.Label)
+	baseParams = append(baseParams, b.label)
 	baseParams = append(baseParams, uint64(data.Slot))
 	baseParams = append(baseParams, hex.EncodeToString(data.OldHeadBlock[:]))
 	baseParams = append(baseParams, hex.EncodeToString(data.NewHeadBlock[:]))

--- a/pkg/analysis/metrics.go
+++ b/pkg/analysis/metrics.go
@@ -99,7 +99,8 @@ func (b *ClientLiveData) BlockMetrics(block *api.VersionedProposal, duration flo
 
 	return postgresql.BlockMetricsModel{
 		Slot:                  int(slot),
-		Label:                 b.Eth2Provider.Label,
+		ClientName:            b.client,
+		Label:                 b.label,
 		CorrectSource:         totalCorrectSource,
 		CorrectTarget:         totalCorrectTarget,
 		CorrectHead:           totalCorrectHead,

--- a/pkg/app/prometheus_exporter.go
+++ b/pkg/app/prometheus_exporter.go
@@ -42,8 +42,8 @@ func (s *AppService) runClientsPrometheusMetrics() {
 			case <-ticker.C:
 				log.Infof("prometheus summary:")
 				for _, item := range s.Analyzers {
-					ProposalsUp.WithLabelValues(item.Eth2Provider.Label).Set(float64(item.Monitoring.ProposalStatus))
-					log.Infof("Endpoint: %s, status: %d", item.Eth2Provider.Label, item.Monitoring.ProposalStatus)
+					ProposalsUp.WithLabelValues(item.GetLabel()).Set(float64(item.Monitoring.ProposalStatus))
+					log.Infof("Endpoint: %s, status: %d", item.GetLabel(), item.Monitoring.ProposalStatus)
 				}
 
 			case <-s.ctx.Done():

--- a/pkg/app/service.go
+++ b/pkg/app/service.go
@@ -146,7 +146,7 @@ func (s *AppService) RunAttestations() {
 	for _, item := range s.Analyzers {
 		err := item.Eth2Provider.Api.Events(s.ctx, []string{"attestation"}, item.HandleAttestationEvent) // every new head
 		if err != nil {
-			log.Panicf("failed to subscribe to head events: %s, label: %s", err, item.Eth2Provider.Label)
+			log.Panicf("failed to subscribe to head events: %s, label: %s", err, item.GetLabel())
 		}
 
 	}
@@ -159,7 +159,7 @@ func (s *AppService) RunReOrgs() {
 	for _, item := range s.Analyzers {
 		err := item.Eth2Provider.Api.Events(s.ctx, []string{"chain_reorg"}, item.HandleAttestationEvent) // every new head
 		if err != nil {
-			log.Panicf("failed to subscribe to reorg events: %s, label: %s", err, item.Eth2Provider.Label)
+			log.Panicf("failed to subscribe to reorg events: %s, label: %s", err, item.GetLabel())
 		}
 
 	}
@@ -185,7 +185,7 @@ func (s *AppService) RunMainRoutine(wg *sync.WaitGroup) {
 	for _, item := range s.Analyzers {
 		err := item.Eth2Provider.Api.Events(s.ctx, []string{"head"}, item.HandleHeadEvent) // every new head
 		if err != nil {
-			log.Panicf("failed to subscribe to head events: %s, label: %s", err, item.Eth2Provider.Label)
+			log.Panicf("failed to subscribe to head events: %s, label: %s", err, item.GetLabel())
 		}
 
 	}

--- a/pkg/client_api/clientapi.go
+++ b/pkg/client_api/clientapi.go
@@ -16,9 +16,8 @@ var (
 )
 
 type APIClient struct {
-	ctx   context.Context
-	Api   *http.Service
-	Label string
+	ctx context.Context
+	Api *http.Service
 }
 
 func NewAPIClient(ctx context.Context, label string, cliEndpoint string, timeout time.Duration) (*APIClient, error) {
@@ -38,12 +37,11 @@ func NewAPIClient(ctx context.Context, label string, cliEndpoint string, timeout
 		log.Error("gernerating the http api client")
 	}
 	return &APIClient{
-		ctx:   ctx,
-		Api:   hc,
-		Label: label,
+		ctx: ctx,
+		Api: hc,
 	}, nil
 }
 
 func (p APIClient) String() string {
-	return p.Label + "->" + p.Api.Address()
+	return p.Api.Address()
 }

--- a/pkg/postgresql/block_score.go
+++ b/pkg/postgresql/block_score.go
@@ -17,6 +17,7 @@ var (
 	CREATE_SCORE_TABLE = `
 		CREATE TABLE IF NOT EXISTS t_score_metrics(
 			f_slot INT,
+			f_client_name TEXT,
 			f_label TEXT,
 			f_score FLOAT,
 			f_duration FLOAT,
@@ -36,6 +37,7 @@ var (
 	InsertNewScore = `
 		INSERT INTO t_score_metrics (	
 			f_slot, 
+			f_client_name,
 			f_label, 
 			f_score,
 			f_duration,
@@ -50,7 +52,7 @@ var (
 			f_proposer_slashing_score,
 			f_attester_slashing_score,
 			f_sync_score)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15);`
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16);`
 )
 
 // in case the table did not exist

--- a/pkg/postgresql/block_score.go
+++ b/pkg/postgresql/block_score.go
@@ -65,6 +65,7 @@ func (p *PostgresDBService) createScoreMetricsTable(ctx context.Context, pool *p
 
 type BlockMetricsModel struct {
 	Slot                  int
+	ClientName            string
 	Label                 string
 	Score                 float64
 	Duration              float64

--- a/pkg/utils/client.go
+++ b/pkg/utils/client.go
@@ -21,6 +21,8 @@ func CheckValidClientName(name string) bool {
 		return true
 	case LodestarClient:
 		return true
+	case GrandineClient:
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
# Motivation
As the tool is used to obtain live data from the different consensus clients, it is very useful to know which client produced the block.
As we recently inserted a new parameter from the command line, we can now store it in the database.

# Description
We have updated the field `label` which now stores both the label and the endpoint (separated by `_`, just in case this is repeated across clients.
Apart from that, a new column has been added with the client name, which should make it easier to analyse data.

# Proof
![image](https://github.com/migalabs/streameth/assets/18716811/7a7191d6-4a36-4835-9620-2cefb71d6613)
