### PR TITLE
Prepare validator proposals and check synced node

### DIFF
--- a/pkg/analysis/analyzer.go
+++ b/pkg/analysis/analyzer.go
@@ -114,6 +114,13 @@ func (b *ClientLiveData) ProposeNewBlock(slot phase0.Slot) {
 		Score: -1,
 	}
 
+	if slot > (phase0.Slot(b.CurrentHeadSlot) + utils.SlotsPerEpoch) {
+		// beacon node is not synced
+		b.Monitoring.ProposalStatus = 0
+		log.Errorf("node is not synced(proposal slot: %d, node head slot: %d), not proposing", slot, b.CurrentHeadSlot)
+		return
+	}
+
 	snapshot := time.Now()
 	block, err := b.Eth2Provider.Api.Proposal(b.ctx, &proposalOpts) // ask for block proposal
 	blockTime := time.Since(snapshot).Seconds()                     // time to generate block

--- a/pkg/analysis/events.go
+++ b/pkg/analysis/events.go
@@ -54,10 +54,9 @@ func (b *ClientLiveData) HandleHeadEvent(event *api_v1.Event) {
 		}
 	}
 	b.CurrentHeadSlot = uint64(data.Slot)
-	if b.CurrentHeadSlot%utils.SlotsPerEpoch == (utils.SlotsPerEpoch - 1) {
-		// last slot of epoch, prepare next
-		//  epoch is the next slot divided by 32
-		epoch := phase0.Epoch((b.CurrentHeadSlot + 1) / utils.SlotsPerEpoch)
+	if b.CurrentHeadSlot%utils.SlotsPerEpoch == (utils.SlotsPerEpoch / 2) {
+		// by halfway the epoch prepare proposers for next epoch
+		epoch := phase0.Epoch((b.CurrentHeadSlot)/utils.SlotsPerEpoch) + 1 // next epoch
 
 		go b.ProcessEpochTasks(epoch)
 	}
@@ -176,6 +175,6 @@ func (b *ClientLiveData) ProcessEpochTasks(epoch phase0.Epoch) {
 	err = b.Eth2Provider.SubmitProposalPreparation(vals)
 
 	if err != nil {
-		log.Errorf("could not submit a proposal peparation: %s", err)
+		log.Errorf("could not process epoch %d tasks: %s", epoch, err)
 	}
 }

--- a/pkg/analysis/history.go
+++ b/pkg/analysis/history.go
@@ -67,7 +67,7 @@ func (b *ClientLiveData) BuildHistory() bool {
 	currentHead, err := b.Eth2Provider.Api.BeaconBlockHeader(b.ctx, &headOpts)
 
 	if err != nil {
-		log.Panicf("could not retrieve current head: ", err)
+		log.Panicf("could not retrieve current head: %s", err)
 	}
 	headSlot := currentHead.Data.Header.Message.Slot
 
@@ -94,7 +94,7 @@ func (b *ClientLiveData) BuildHistory() bool {
 				log.Debugf("Missed block!")
 				continue
 			} else {
-				log.Panicf("could not retrieve historical block at slot: %d: ", i, err)
+				log.Panicf("could not retrieve historical block at slot: %d: %s", i, err)
 			}
 		}
 		if block == nil {
@@ -103,7 +103,7 @@ func (b *ClientLiveData) BuildHistory() bool {
 		}
 		root, err := block.Data.Root()
 		if err != nil {
-			log.Panicf("could not retrieve block root from block %d: ", i, err)
+			log.Panicf("could not retrieve block root from block %d: %s", i, err)
 		}
 		b.BlockRootHistory[i] = root
 

--- a/pkg/client_api/block.go
+++ b/pkg/client_api/block.go
@@ -42,13 +42,18 @@ func (b *APIClient) ProposeNewBlock(slot phase0.Slot, client string) (api.Versio
 
 }
 
-func (s APIClient) SubmitProposalPreparation() error {
-	err := s.Api.SubmitProposalPreparations(s.ctx, []*v1.ProposalPreparation{
-		&v1.ProposalPreparation{
-			ValidatorIndex: 0,
+func (s APIClient) SubmitProposalPreparation(vals []phase0.ValidatorIndex) error {
+
+	proposalOpts := make([]*v1.ProposalPreparation, len(vals))
+
+	for i, item := range vals {
+		proposalOpts[i] = &v1.ProposalPreparation{
+			ValidatorIndex: item,
 			FeeRecipient:   utils.CreateEmptyFeeRecipient(),
-		},
-	})
+		}
+	}
+
+	err := s.Api.SubmitProposalPreparations(s.ctx, proposalOpts)
 
 	return err
 

--- a/pkg/client_api/block.go
+++ b/pkg/client_api/block.go
@@ -52,7 +52,7 @@ func (s APIClient) SubmitProposalPreparation(vals []phase0.ValidatorIndex) error
 			FeeRecipient:   utils.CreateEmptyFeeRecipient(),
 		}
 	}
-
+	log.Infof("preparing proposals in epoch for validators: %+v", vals)
 	err := s.Api.SubmitProposalPreparations(s.ctx, proposalOpts)
 
 	return err

--- a/pkg/client_api/block.go
+++ b/pkg/client_api/block.go
@@ -1,0 +1,55 @@
+package client_api
+
+import (
+	"fmt"
+	"time"
+
+	v1 "github.com/attestantio/go-eth2-client/api/v1"
+
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/migalabs/streameth/pkg/utils"
+)
+
+// Asks for a block proposal to the client and stores score in the database
+func (b *APIClient) ProposeNewBlock(slot phase0.Slot, client string) (api.VersionedProposal, time.Duration, error) {
+	log.Debugf("proposing new block: %d\n", slot)
+
+	skipRandaoVerification := false // only needed for Lighthouse, Nimbus and Grandine
+
+	if client == utils.LighthouseClient ||
+		client == utils.NimbusClient ||
+		client == utils.GrandineClient {
+		skipRandaoVerification = true
+	}
+
+	proposalOpts := api.ProposalOpts{
+		Slot:                   slot,
+		RandaoReveal:           utils.CreateInfinityRandaoReveal(),
+		Graffiti:               utils.GraffitiFromString(""),
+		SkipRandaoVerification: skipRandaoVerification,
+	}
+
+	snapshot := time.Now()
+	block, err := b.Api.Proposal(b.ctx, &proposalOpts) // ask for block proposal
+	blockTime := time.Since(snapshot)                  // time to generate block
+
+	if err != nil {
+		return api.VersionedProposal{}, 0 * time.Second, fmt.Errorf("error proposing block at slot %d: %s", slot, err)
+	}
+
+	return *block.Data, blockTime, nil
+
+}
+
+func (s APIClient) SubmitProposalPreparation() error {
+	err := s.Api.SubmitProposalPreparations(s.ctx, []*v1.ProposalPreparation{
+		&v1.ProposalPreparation{
+			ValidatorIndex: 0,
+			FeeRecipient:   utils.CreateEmptyFeeRecipient(),
+		},
+	})
+
+	return err
+
+}

--- a/pkg/client_api/duties.go
+++ b/pkg/client_api/duties.go
@@ -1,0 +1,28 @@
+package client_api
+
+import (
+	"fmt"
+
+	"github.com/attestantio/go-eth2-client/api"
+	v1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+func (s *APIClient) ProposerDuties(epoch phase0.Epoch) ([]*v1.ProposerDuty, error) {
+
+	proposerDuties, err := s.Api.ProposerDuties(s.ctx, &api.ProposerDutiesOpts{
+		Epoch: epoch,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("could not get proposer duties in epoch %d: %s", epoch, err)
+	}
+
+	duties := make([]*v1.ProposerDuty, len(proposerDuties.Data))
+
+	for i, item := range proposerDuties.Data {
+		duties[i] = item
+	}
+
+	return duties, nil
+}

--- a/pkg/utils/block.go
+++ b/pkg/utils/block.go
@@ -6,12 +6,15 @@ import (
 
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
 const (
 	InfinityRandaoReveal = "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	EmptyFeeRecipient    = "0x0000000000000000000000000000000000000000"
+	SlotsPerEpoch        = 32
 )
 
 func CreateInfinityRandaoReveal() phase0.BLSSignature {
@@ -23,6 +26,17 @@ func CreateInfinityRandaoReveal() phase0.BLSSignature {
 	}
 
 	return randaoReveal
+}
+
+func CreateEmptyFeeRecipient() bellatrix.ExecutionAddress {
+	// Infinity randao always required
+	feeRecipient := bellatrix.ExecutionAddress{}
+	bs, err := hex.DecodeString(EmptyFeeRecipient)
+	if err == nil {
+		copy(feeRecipient[:], bs)
+	}
+
+	return feeRecipient
 }
 
 func GraffitiFromString(graffitiStr string) [32]byte {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,5 +2,5 @@ package utils
 
 const (
 	CliName = "StreamEth"
-	Version = "v1.0.0"
+	Version = "v1.1.0"
 )


### PR DESCRIPTION
# Motivation
The Beacon API has received upgrades and a new endpoint was added some time ago: 
[/eth/v1/validator/prepare_beacon_proposer](https://ethereum.github.io/beacon-APIs/#/Validator/prepareBeaconProposer)

With this endpoint, it is possible to request the beacon node to prepare to propose blocks for the given validators.

# Description
As this tool mainly requests the beacon node to propose blocks. we aim to introduce the above mentioned endpoint, which should enable the beacon node to be more prepared to propose blocks and, thus, expect more block to be proposed.


# Proof of Success

## StreamEth
```
streameth_1            | time="2024-02-23T13:52:27Z" level=debug msg="submitting proposal preparation..." module=Analysis
streameth_1            | time="2024-02-23T13:52:27Z" level=info msg="preparing proposals in epoch for validators: [603595 952333 388236 421233 828374 1122484 496193 174275 351693 418939 1191870 445780 689434 796490 1138324 828360 1206235 365879 806062 450855 602679 160062 721359 329531 110681 935680 1016136 717804 958202 911989 855054 189505]" module=API-Cli
```

## The beacon node
```
INF 2024-02-23 13:52:27.437+00:00 Prepared beacon proposers                  topics="rest_validatorapi" numUpdatedFeeRecipients=32 numRefreshedFeeRecipients=0
```